### PR TITLE
Lock terminal-table to 1.7.3

### DIFF
--- a/datamix.gemspec
+++ b/datamix.gemspec
@@ -16,7 +16,9 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = ">= 2.1.0"
 
-  s.add_runtime_dependency 'terminal-table', '~> 1.7'
+  # Locking to 1.7.3 since 1.8.0 seem to be bugged
+  # https://github.com/tj/terminal-table/issues/103
+  s.add_runtime_dependency 'terminal-table', '1.7.3'
 
   s.add_development_dependency 'runfile', '~> 0.9'
   s.add_development_dependency 'runfile-tasks', '~> 0.4'

--- a/lib/datamix/version.rb
+++ b/lib/datamix/version.rb
@@ -1,3 +1,3 @@
 module DataMix
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
terminal-table v1.8.0 is causing some errors, locking to 1.7.3